### PR TITLE
Make block non-escapable

### DIFF
--- a/Then/Then.swift
+++ b/Then/Then.swift
@@ -32,7 +32,7 @@ extension Then {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    func then(block: Self -> Void) -> Self {
+    func then(@noescape block: Self -> Void) -> Self {
         block(self)
         return self
     }


### PR DESCRIPTION
This actually allows to not use self in closures if you are referring to class properties. And probably such construct should not allow closure to escape anyway =)
