### PR TITLE
Added "when", which will only execute when initial condition is met

### DIFF
--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -37,6 +37,19 @@ extension Then {
         return self
     }
     
+    /// Makes it available to set properties with closures just after initializing, when condition is met.
+    ///
+    ///     let label = UILabel().when(true) {
+    ///         $0.textAlignment = .Center
+    ///         $0.textColor = UIColor.blackColor()
+    ///         $0.text = "Hello, World!"
+    ///     }
+    public func when(execute : Bool, @noescape _ block: Self -> Void) -> Self {
+        if execute {
+            block(self)
+        }
+        return self
+    }
 }
 
 extension NSObject: Then {}

--- a/ThenTests/ThenTests.swift
+++ b/ThenTests/ThenTests.swift
@@ -12,12 +12,37 @@ import XCTest
 class ThenTests: XCTestCase {
 
     func testThen() {
+        // Configure default UILabel
         let label = UILabel().then {
             $0.text = "I am a label."
             $0.textColor = .blackColor()
         }
+        
+        // Test color and text equality
         XCTAssertEqual(label.text, "I am a label.")
         XCTAssertEqual(label.textColor, UIColor.blackColor())
     }
     
+    
+    func testWhen() {
+        // Configure default UILabel
+        let label = UILabel().when(true) {
+            $0.text = "I am a label."
+            $0.textColor = .blackColor()
+        }
+        
+        // Test color and text equality
+        XCTAssertEqual(label.text, "I am a label.")
+        XCTAssertEqual(label.textColor, UIColor.blackColor())
+        
+        // Try to reconfigure it
+        label.when(false) {
+            $0.text = "I will break your test if true."
+            $0.textColor = .whiteColor()
+        }
+        
+        // Test color and text equality again
+        XCTAssertEqual(label.text, "I am a label.")
+        XCTAssertEqual(label.textColor, UIColor.blackColor())
+    }
 }


### PR DESCRIPTION
I propose we add one more function - when. This serves exactly the same purpose, but "then" is only executed when initial condition is met. This is extremely useful in a lot of cases, as it changes often used syntax 

``` swift
if (true) {
    label.then {
        ...
    }
}
```

to 

``` swift
label.when(true) {
    ...
}
```

The only problem is that it does not fit with name of your repository :D but I think it is okay :)
