### PR TITLE
Add ability to call block on Optional

### DIFF
--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -41,3 +41,19 @@ extension Then {
 }
 
 extension NSObject: Then {}
+
+extension Optional
+{
+    /// Ability to call methods on optional values, such as weak self.
+    ///
+    ///     method.doSomethingWithCompletion { [weak self] in 
+    ///         self.then {
+    ///             $0.doSomething() // Notice that $0 is unwrapped 
+    ///         }
+    ///     }
+    public func then(@noescape block: Wrapped -> Void) {
+        if case .Some(let wrapped) = self {
+            block(wrapped)
+        }
+    }
+}

--- a/ThenTests/ThenTests.swift
+++ b/ThenTests/ThenTests.swift
@@ -34,5 +34,20 @@ class ThenTests: XCTestCase {
         XCTAssertEqual(user.name, "devxoul")
         XCTAssertEqual(user.email, "devxoul@gmail.com")
     }
+    
+    func testThenCanBeCalledOnWrappedOptional() {
+        let intValue : Int? = 5
+        
+        intValue.then {
+            XCTAssertEqual($0, 5)
+        }
+    }
+    
+    func testThenWillNotBeCalledOnNilOptional() {
+        let intValue : Int? = nil
+        intValue.then { _ in
+            XCTFail()
+        }
+    }
 
 }


### PR DESCRIPTION
Hey!

I really like then approach and wanted to extend it for optionals. Feature implemented in this PR is different from current Then, however similar in ideology.

It allows calling any custom block of code on optional, if optional contains `.Some`. Most common case for this would be `[weak self]` in various kinds of completion blocks, however there are a lot more cases where you can use this approach.

For example, let's say we need to use weak self, however pass self somewhere else as unwrapped optional, like this:

``` swift
self.doSomethingWithCompletion { [weak self] result in
    self?.parseResult(result, receivedFrom: self!)
    self?.doSomething()
}
```

This would require multiple optional unwrappings and possibly even force unwraps. Another way to do this is to unwrap with guard: 

``` swift
self.doSomethingWithCompletion { [weak self] result in
    guard let strongSelf = self else { return }
    strongSelf.parseResult(result, receivedFrom: strongSelf)
    strongSelf.doSomething()
}
```

Unwraps are gone, however we introduced new variable for self, which is not really convenient. 
Meet Then from this PR:

``` swift
self.doSomethingWithCompletion { [weak self] result in
    self.then {
        $0.parseResult(result, receivedFrom: $0)
        $0.doSomething()
    }
}
```
