### PR TITLE
Add extension for AnyObject to get rid of 'return' statement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,23 +123,21 @@ Installation
 Trouble Shooting
 ----------------
 
-- **Compile error with only one parameter**
+- **Compile error with single line closure on value types**
 
-    Using `then()` with only one parameter causes compile error.
-    
     ```swift
-    let queue = NSOperationQueue().then {
-        $0.maxConcurrentOperationCount = 1 // Compile Error!
-    }
+    let value = MyStruct().then {
+        $0.isThenAwesome = true
+    } // Compile Error!
     ```
-        
-    > Cannot convert value of type '_ -> ()' to expected argument type 'inout NSOperationQueue -> Void'
-        
-    **Possible workaround**: Just return.
+
+    > error: Cannot convert value of type '_ -> ()' to expected argument type 'inout MyStruct -> Void'
+
+    A possible workaround is: Just add return statement.
     
     ```swift
-    let queue = NSOperationQueue().then {
-        $0.maxConcurrentOperationCount = 1
+    let value = MyStruct().then {
+        $0.isThenAwesome = true
         return // put this line
     }
     ```

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -23,7 +23,8 @@
 import Foundation
 
 public protocol Then {}
-extension Then {
+
+extension Then where Self: Any {
 
     /// Makes it available to set properties with closures just after initializing.
     ///
@@ -38,6 +39,22 @@ extension Then {
         return copy
     }
 
+}
+
+extension Then where Self: AnyObject {
+
+    /// Makes it available to set properties with closures just after initializing.
+    ///
+    ///     let label = UILabel().then {
+    ///         $0.textAlignment = .Center
+    ///         $0.textColor = UIColor.blackColor()
+    ///         $0.text = "Hello, World!"
+    ///     }
+    public func then(@noescape block: Self -> Void) -> Self {
+        block(self)
+        return self
+    }
+    
 }
 
 extension NSObject: Then {}


### PR DESCRIPTION
#### Problem

When using a closure with single line:

``` swift
let user = User() {
    $0.name = "abc"
}
```

Then Swift compiler says:

> error: cannot convert value of type '_ -> ()' to expected argument type 'inout User -> Void'

A possible workaround until now is adding a `return` statement.

``` swift
let user = User() {
    $0.name = "abc"
    return
}
```
#### Solution

The cause of the error is:  an `inout` parameter. It seemed like a Swift bug. In order to get rid of `return` statement, I've made a new extension on `AnyObject` that doesn't use `inout` parameter.
#### Limitation

This workaround is only available for reference types.
