### PR TITLE
Single argument function types require parentheses

### DIFF
--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,7 +33,7 @@ extension Then where Self: Any {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape inout Self -> Void) -> Self {
+    public func then(_ block: @noescape (inout Self) -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy
@@ -50,7 +50,7 @@ extension Then where Self: AnyObject {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape Self -> Void) -> Self {
+    public func then(_ block: @noescape (Self) -> Void) -> Self {
         block(self)
         return self
     }


### PR DESCRIPTION
This is a quick fix for errors in Xcode 8 beta 3 to satisfy parens requirements
