### PR TITLE
Xcode 8 beta 6: Removed deprecated `@noescape`s

### DIFF
--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,7 +33,7 @@ extension Then where Self: Any {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape (inout Self) -> Void) -> Self {
+    public func then(_ block: (inout Self) -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy
@@ -50,7 +50,7 @@ extension Then where Self: AnyObject {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape (Self) -> Void) -> Self {
+    public func then(_ block: (Self) -> Void) -> Self {
         block(self)
         return self
     }


### PR DESCRIPTION
As of Xcode 8b6's Swift 3.0, closures are now non-escaping by default, so the `@noescape` keyword is no longer necessary, and deprecated _(Xcode now emits on usages `warning: @noescape is the default and is deprecated`)_.  More info on this change at https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md and http://adcdownload.apple.com/Developer_Tools/Xcode_8_beta_6/Release_Notes_for_Xcode_8_beta_6.pdf .
- Removed uses of deprecated `@noescape` keyword.  Double-checked to make sure there were no formerly-escaping closures that would need the new `@escaping` keyword.
