### PR TITLE
Updated `.travis.yml` to use Xcode 8 for this Swift-3.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode8
 script:
     - xctool -scheme 'Then-iOS' -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test -parallelize
     - xctool -scheme 'Then-OSX' test -parallelize


### PR DESCRIPTION
Changed the `osx_image` in the `.travis.yml` to `xcode8` (Xcode 8 is necessary to compile with Swift 3), which is now a supported option according to https://docs.travis-ci.com/user/languages/objective-c .

While I don't know what beta this Xcode 8 is (at time of writing, the latest is beta 6), we'll find out soon enough, I guess?  And `xcode8` would include future betas & GM seeds & release, so it can't hurt.
