### PR TITLE
Let's Swift 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
 osx_image: xcode8
 script:
-    - xctool -scheme 'Then-iOS' -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test -parallelize
-    - xctool -scheme 'Then-OSX' test -parallelize
+    - xcodebuild -scheme 'Then-iOS' -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty -c
+    - xcodebuild -scheme 'Then-OSX' test | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode8
 script:
     - xctool -scheme 'Then-iOS' -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test -parallelize
     - xctool -scheme 'Then-OSX' test -parallelize

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Then
 ====
 
-![Swift](https://img.shields.io/badge/Swift-2.2-orange.svg)
+![Swift](https://img.shields.io/badge/Swift-3.0-orange.svg)
 [![Build Status](https://travis-ci.org/devxoul/Then.svg?branch=master)](https://travis-ci.org/devxoul/Then)
 [![CocoaPods](http://img.shields.io/cocoapods/v/Then.svg)](https://cocoapods.org/pods/Then)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
@@ -16,9 +16,9 @@ Initialize UILabel **then** set its properties.
 
 ```swift
 let label = UILabel().then {
-    $0.textAlignment = .Center
-    $0.textColor = .blackColor()
-    $0.text = "Hello, World!"
+  $0.textAlignment = .Center
+  $0.textColor = .blackColor()
+  $0.text = "Hello, World!"
 }
 ```
 
@@ -26,31 +26,56 @@ This is equivalent to:
 
 ```swift
 let label: UILabel = {
-    let label = UILabel()
-    label.textAlignment = .Center
-    label.textColor = .blackColor()
-    label.text = "Hello, World!"
-    return label
+  let label = UILabel()
+  label.textAlignment = .Center
+  label.textColor = .blackColor()
+  label.text = "Hello, World!"
+  return label
 }()
 ```
 
-You can use `then()` to all of `NSObject` subclasses.
 
-```swift
-let queue = NSOperationQueue().then {
-    $0.maxConcurrentOperationCount = 1
-}
-```
+Tips and Tricks
+---------------
 
-Want to use with your own types? Just make extensions.
+- You can use `then()` to all of `NSObject` subclasses.
 
-```swift
-extension MyType: Then {}
+    ```swift
+    let queue = OperationQueue().then {
+      $0.maxConcurrentOperationCount = 1
+    }
+    ```
 
-let instance = MyType().then {
-    $0.really = "awesome!"
-}
-```
+- Want to use with your own types? Just make extensions.
+
+    ```swift
+    extension MyType: Then {}
+    
+    let instance = MyType().then {
+      $0.really = "awesome!"
+    }
+    ```
+
+- Use `with()` when copying the value types.
+
+    ```swift
+    let newFrame = oldFrame.with {
+      $0.size.width = 200
+      $0.size.height = 100
+    }
+    newFrame.width // 200
+    newFrame.height // 100
+    ```
+
+- Use `do()` to do something with less typing.
+
+    ```swift
+    UserDefaults.standard.do {
+      $0.set("devxoul", forKey: "username")
+      $0.set("devxoul@gmail.com", forKey: "email")
+      $0.synchronize()
+    }
+    ```
 
 
 Real World Example
@@ -62,20 +87,20 @@ Here's an example usage in an UIViewController subclass.
 final class MyViewController: UIViewController {
 
     let titleLabel = UILabel().then {
-        $0.textColor = .blackColor()
-        $0.textAlignment = .Center
+      $0.textColor = .black
+      $0.textAlignment = .center
     }
 
     let tableView = UITableView().then {
-        $0.backgroundColor = .clearColor()
-        $0.separatorStyle = .None
-        $0.registerClass(MyCell.self, forCellReuseIdentifier: "myCell")
+      $0.backgroundColor = .clear
+      $0.separatorStyle = .none
+      $0.register(MyCell.self, forCellReuseIdentifier: "myCell")
     }
 
     override func viewDidLoad() {
-        super.viewDidLoad()
-        self.view.addSubview(self.titleLabel)
-        self.view.addSubview(self.tableView)
+      super.viewDidLoad()
+      self.view.addSubview(self.titleLabel)
+      self.view.addSubview(self.tableView)
     }
 
 }
@@ -109,10 +134,10 @@ Installation
     import PackageDescription
 
     let package = Package(
-        name: "MyAwesomeApp",
-        dependencies: [
-            .Package(url: "https://github.com/devxoul/Then", "1.0.3"),
-        ]
+      name: "MyAwesomeApp",
+      dependencies: [
+        .Package(url: "https://github.com/devxoul/Then", "1.0.3"),
+      ]
     )
     ```
 

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -28,12 +28,11 @@ extension Then where Self: Any {
 
     /// Makes it available to set properties with closures just after initializing.
     ///
-    ///     let label = UILabel().then {
-    ///         $0.textAlignment = .Center
-    ///         $0.textColor = UIColor.blackColor()
-    ///         $0.text = "Hello, World!"
+    ///     let frame = CGRect().with {
+    ///         $0.origin.x = 10
+    ///         $0.size.width = 100
     ///     }
-    public func then(_ block: (inout Self) -> Void) -> Self {
+    public func with(_ block: (inout Self) -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,7 +33,7 @@ extension Then where Self: Any {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(@noescape block: inout Self -> Void) -> Self {
+    public func then(block: @noescape inout Self -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy
@@ -50,7 +50,7 @@ extension Then where Self: AnyObject {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(@noescape block: Self -> Void) -> Self {
+    public func then(block: @noescape Self -> Void) -> Self {
         block(self)
         return self
     }

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,7 +33,7 @@ extension Then where Self: Any {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape (inout Self) -> Void) -> Self {
+    public func then(_ block: (inout Self) -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy
@@ -50,7 +50,7 @@ extension Then where Self: AnyObject {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape (Self) -> Void) -> Self {
+    public func then(_ block: (Self) -> Void) -> Self {
         block(self)
         return self
     }

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -27,44 +27,44 @@ public protocol Then {}
 
 extension Then where Self: Any {
 
-    /// Makes it available to set properties with closures just after initializing.
-    ///
-    ///     let frame = CGRect().with {
-    ///         $0.origin.x = 10
-    ///         $0.size.width = 100
-    ///     }
-    public func with(_ block: (inout Self) -> Void) -> Self {
-        var copy = self
-        block(&copy)
-        return copy
-    }
+  /// Makes it available to set properties with closures just after initializing.
+  ///
+  ///     let frame = CGRect().with {
+  ///       $0.origin.x = 10
+  ///       $0.size.width = 100
+  ///     }
+  public func with(_ block: (inout Self) -> Void) -> Self {
+    var copy = self
+    block(&copy)
+    return copy
+  }
 
 }
 
 extension Then where Self: AnyObject {
 
-    /// Makes it available to set properties with closures just after initializing.
-    ///
-    ///     let label = UILabel().then {
-    ///         $0.textAlignment = .Center
-    ///         $0.textColor = UIColor.blackColor()
-    ///         $0.text = "Hello, World!"
-    ///     }
-    public func then(_ block: (Self) -> Void) -> Self {
-        block(self)
-        return self
-    }
+  /// Makes it available to set properties with closures just after initializing.
+  ///
+  ///     let label = UILabel().then {
+  ///       $0.textAlignment = .Center
+  ///       $0.textColor = UIColor.blackColor()
+  ///       $0.text = "Hello, World!"
+  ///     }
+  public func then(_ block: (Self) -> Void) -> Self {
+    block(self)
+    return self
+  }
 
-    /// Makes it available to execute something with closures.
-    ///
-    ///     UserDefaults.standard.do {
-    ///         $0.set("devxoul", forKey: "username")
-    ///         $0.set("devxoul@gmail.com", forKey: "email")
-    ///         $0.synchronize()
-    ///     }
-    public func `do`(_ block: (Self) -> Void) {
-        block(self)
-    }
+  /// Makes it available to execute something with closures.
+  ///
+  ///     UserDefaults.standard.do {
+  ///       $0.set("devxoul", forKey: "username")
+  ///       $0.set("devxoul@gmail.com", forKey: "email")
+  ///       $0.synchronize()
+  ///     }
+  public func `do`(_ block: (Self) -> Void) {
+    block(self)
+  }
 
 }
 

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,7 +33,7 @@ extension Then where Self: Any {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape inout Self -> Void) -> Self {
+    public func then(_ block: @noescape (inout Self) -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy
@@ -50,7 +50,7 @@ extension Then where Self: AnyObject {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(_ block: @noescape Self -> Void) -> Self {
+    public func then(_ block: @noescape (Self) -> Void) -> Self {
         block(self)
         return self
     }

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -53,7 +53,18 @@ extension Then where Self: AnyObject {
         block(self)
         return self
     }
-    
+
+    /// Makes it available to execute something with closures.
+    ///
+    ///     UserDefaults.standard.do {
+    ///         $0.set("devxoul", forKey: "username")
+    ///         $0.set("devxoul@gmail.com", forKey: "email")
+    ///         $0.synchronize()
+    ///     }
+    public func `do`(_ block: (Self) -> Void) {
+        block(self)
+    }
+
 }
 
 extension NSObject: Then {}

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,7 +33,7 @@ extension Then where Self: Any {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(block: @noescape inout Self -> Void) -> Self {
+    public func then(_ block: @noescape inout Self -> Void) -> Self {
         var copy = self
         block(&copy)
         return copy
@@ -50,7 +50,7 @@ extension Then where Self: AnyObject {
     ///         $0.textColor = UIColor.blackColor()
     ///         $0.text = "Hello, World!"
     ///     }
-    public func then(block: @noescape Self -> Void) -> Self {
+    public func then(_ block: @noescape Self -> Void) -> Self {
         block(self)
         return self
     }

--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import Foundation
+import CoreGraphics
 
 public protocol Then {}
 
@@ -68,3 +69,8 @@ extension Then where Self: AnyObject {
 }
 
 extension NSObject: Then {}
+
+extension CGPoint: Then {}
+extension CGRect: Then {}
+extension CGSize: Then {}
+extension CGVector: Then {}

--- a/Then.xcodeproj/project.pbxproj
+++ b/Then.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 				PRODUCT_NAME = Then;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -703,6 +704,7 @@
 				PRODUCT_NAME = Then;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -722,6 +724,7 @@
 				PRODUCT_NAME = Then;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -743,6 +746,7 @@
 				PRODUCT_NAME = Then;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};

--- a/Then.xcodeproj/project.pbxproj
+++ b/Then.xcodeproj/project.pbxproj
@@ -310,9 +310,11 @@
 				TargetAttributes = {
 					0340E5981C2BE4F400020202 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					0340E5A21C2BE4F400020202 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					03545BCF1C417B7A00F4D3B9 = {
 						CreatedOnToolsVersion = 7.2;
@@ -573,6 +575,7 @@
 				PRODUCT_NAME = Then;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -591,6 +594,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Then;
 				PRODUCT_NAME = Then;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -600,6 +604,7 @@
 				INFOPLIST_FILE = "Support/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -609,6 +614,7 @@
 				INFOPLIST_FILE = "Support/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Then.xcodeproj/project.pbxproj
+++ b/Then.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Suyeol Jeon";
 				TargetAttributes = {
 					0340E5981C2BE4F400020202 = {
@@ -318,16 +318,20 @@
 					};
 					03545BCF1C417B7A00F4D3B9 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					03545BDF1C417C1900F4D3B9 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					C43F90C81C3C288D008185BF = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					C43F90D61C3C2941008185BF = {
 						CreatedOnToolsVersion = 7.2;
 						DevelopmentTeam = GGU39CDBL2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -481,8 +485,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -530,8 +536,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -552,6 +560,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -563,6 +572,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -583,6 +593,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -628,6 +639,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -641,6 +653,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -651,6 +664,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
 			name = Debug;
@@ -662,6 +676,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
 			name = Release;
@@ -669,7 +684,7 @@
 		C43F90CE1C3C288D008185BF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -690,7 +705,7 @@
 		C43F90CF1C3C288D008185BF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -712,6 +727,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -734,6 +750,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Then.xcodeproj/xcshareddata/xcschemes/Then-OSX.xcscheme
+++ b/Then.xcodeproj/xcshareddata/xcschemes/Then-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Then.xcodeproj/xcshareddata/xcschemes/Then-iOS.xcscheme
+++ b/Then.xcodeproj/xcshareddata/xcschemes/Then-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Then.xcodeproj/xcshareddata/xcschemes/Then-tvOS.xcscheme
+++ b/Then.xcodeproj/xcshareddata/xcschemes/Then-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ThenTests/ThenTests.swift
+++ b/ThenTests/ThenTests.swift
@@ -10,38 +10,38 @@ import XCTest
 @testable import Then
 
 struct User {
-    var name: String?
-    var email: String?
+  var name: String?
+  var email: String?
 }
 extension User: Then {}
 
 class ThenTests: XCTestCase {
 
-    func testThen() {
-        let queue = OperationQueue().then {
-            $0.name = "awesome"
-            $0.maxConcurrentOperationCount = 5
-        }
-        XCTAssertEqual(queue.name, "awesome")
-        XCTAssertEqual(queue.maxConcurrentOperationCount, 5)
+  func testThen() {
+    let queue = OperationQueue().then {
+      $0.name = "awesome"
+      $0.maxConcurrentOperationCount = 5
     }
+    XCTAssertEqual(queue.name, "awesome")
+    XCTAssertEqual(queue.maxConcurrentOperationCount, 5)
+  }
 
-    func testWith() {
-        let user = User().with {
-            $0.name = "devxoul"
-            $0.email = "devxoul@gmail.com"
-        }
-        XCTAssertEqual(user.name, "devxoul")
-        XCTAssertEqual(user.email, "devxoul@gmail.com")
+  func testWith() {
+    let user = User().with {
+      $0.name = "devxoul"
+      $0.email = "devxoul@gmail.com"
     }
+    XCTAssertEqual(user.name, "devxoul")
+    XCTAssertEqual(user.email, "devxoul@gmail.com")
+  }
 
-    func testDo() {
-        UserDefaults.standard.do {
-            $0.removeObject(forKey: "username")
-            $0.set("devxoul", forKey: "username")
-            $0.synchronize()
-        }
-        XCTAssertEqual(UserDefaults.standard.string(forKey: "username"), "devxoul")
+  func testDo() {
+    UserDefaults.standard.do {
+      $0.removeObject(forKey: "username")
+      $0.set("devxoul", forKey: "username")
+      $0.synchronize()
     }
+    XCTAssertEqual(UserDefaults.standard.string(forKey: "username"), "devxoul")
+  }
 
 }

--- a/ThenTests/ThenTests.swift
+++ b/ThenTests/ThenTests.swift
@@ -17,8 +17,8 @@ extension User: Then {}
 
 class ThenTests: XCTestCase {
 
-    func testThen_object() {
-        let queue = NSOperationQueue().then {
+    func testThen() {
+        let queue = OperationQueue().then {
             $0.name = "awesome"
             $0.maxConcurrentOperationCount = 5
         }
@@ -26,13 +26,22 @@ class ThenTests: XCTestCase {
         XCTAssertEqual(queue.maxConcurrentOperationCount, 5)
     }
 
-    func testThen_value() {
-        let user = User().then {
+    func testWith() {
+        let user = User().with {
             $0.name = "devxoul"
             $0.email = "devxoul@gmail.com"
         }
         XCTAssertEqual(user.name, "devxoul")
         XCTAssertEqual(user.email, "devxoul@gmail.com")
+    }
+
+    func testDo() {
+        UserDefaults.standard.do {
+            $0.removeObject(forKey: "username")
+            $0.set("devxoul", forKey: "username")
+            $0.synchronize()
+        }
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "username"), "devxoul")
     }
 
 }


### PR DESCRIPTION
This version is compatible with Xcode 8.
- `then()` on value types are renamed to `with()`. (Actually both `then()` and `with()` are available on value types and do the same thing, but `with()` does make more sense because it's about copying.)
  
  ``` swift
  let point = CGPoint().with {
    $0.x = 10
    $0.y = 20
  }
  ```
- Add Then extensions on CoreGraphics by default.
- Add `do()` in class types to execute something without returning value.
  
  ``` swift
  UserDefaults.standard.do {
    $0.set("devxoul", forKey: "username")
    $0.set("devxoul@gmail.com", forKey: "email")
    $0.synchronize()
  }
  ```
