### PR TITLE
@discardableResult `then` and `with`

### DIFF
--- a/Sources/Then.swift
+++ b/Sources/Then.swift
@@ -33,6 +33,7 @@ extension Then where Self: Any {
   ///       $0.origin.x = 10
   ///       $0.size.width = 100
   ///     }
+  @discardableResult
   public func with(_ block: (inout Self) -> Void) -> Self {
     var copy = self
     block(&copy)
@@ -61,6 +62,7 @@ extension Then where Self: AnyObject {
   ///       $0.textColor = UIColor.blackColor()
   ///       $0.text = "Hello, World!"
   ///     }
+  @discardableResult
   public func then(_ block: (Self) -> Void) -> Self {
     block(self)
     return self


### PR DESCRIPTION
Sometimes we needn't return value, like this:

```swift
UINavigationBar.appearance().then({
    $0.tintColor           = .white
    $0.barTintColor        = .ggTint
    $0.isTranslucent       = true
    $0.titleTextAttributes = [
        NSFontAttributeName: UIFont.systemFont(ofSize: 18.0),
        NSForegroundColorAttributeName: UIColor.white
    ]
})
```

No `@discardableResult` will give us a warning says:

```
Result of call to 'then' is unused
```

So what we should to do is just add `@discardableResult` :)