### PR TITLE
fixed XCode's 'Result is unused'-warning

### DIFF
--- a/Sources/Then/Then.swift
+++ b/Sources/Then/Then.swift
@@ -36,7 +36,7 @@ extension Then where Self: Any {
   ///       $0.origin.x = 10
   ///       $0.size.width = 100
   ///     }
-  public func with(_ block: (inout Self) -> Void) -> Self {
+  @discardableResult public func with(_ block: (inout Self) -> Void) -> Self {
     var copy = self
     block(&copy)
     return copy

--- a/Then.podspec
+++ b/Then.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Then"
-  s.version          = "2.2.0"
+  s.version          = "2.2.1"
   s.summary          = "Super sweet syntactic sugar for Swift initializers."
   s.homepage         = "https://github.com/devxoul/Then"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
fix this warning in XCode9+, when using `.with` without using it's result

⚠️ Result of call to 'with' is unused
