### PR TITLE
Fix for CoreGraphics not being available on Linux

### DIFF
--- a/Sources/Then/Then.swift
+++ b/Sources/Then/Then.swift
@@ -21,7 +21,9 @@
 // SOFTWARE.
 
 import Foundation
-import CoreGraphics
+#if !os(Linux)
+    import CoreGraphics
+#endif
 #if os(iOS) || os(tvOS)
   import UIKit.UIGeometry
 #endif
@@ -73,10 +75,13 @@ extension Then where Self: AnyObject {
 
 extension NSObject: Then {}
 
-extension CGPoint: Then {}
-extension CGRect: Then {}
-extension CGSize: Then {}
-extension CGVector: Then {}
+#if !os(Linux)
+    extension CGPoint: Then {}
+    extension CGRect: Then {}
+    extension CGSize: Then {}
+    extension CGVector: Then {}
+#endif
+
 extension Array: Then {}
 extension Dictionary: Then {}
 extension Set: Then {}


### PR DESCRIPTION
I'm using this library in a [Vapor](https://github.com/vapor/vapor) project which needs to run on Linux and I found that Then won't build on Linux because CoreGraphics isn't available so I've wrapped all CoreGraphics import and all the CG* extensions in #if !os(Linux) checks.