### PR TITLE
Remove xcodeproj & xcshareddata ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,5 @@ sourcekitten-output.json
 docs/
 /.build
 /Packages
-/*.xcodeproj
-**/xcuserdata
-**/xcshareddata
 Pods/
 Carthage/


### PR DESCRIPTION
The `.gitignore` file currently is ignoring xcodepoj-related files, which currently does nothing for the Then project because of the decision to go full SPM and remove all xcodeproj stuff (#55).

However, ignoring these files causes issues when Then's source is included in outer Git repo (via git-subtree or direct copying of project) such as when using Carthage or manual library management in conjunction with a generated xcodeproj (`swift package generate-xcodeproj`).  Because Then's `.gitignore` is picked up by the enclosing repo, that prevents the generated xcodeproj or shared schemes from being able to be checked-in— which should arguably be under the discretion of the enclosing repo's build setup.  Removed the ignores for xcodeproj and xcshareddata to fix this, and removed the xcuserdata line too for good measure _(again, if there's no xcodeproj in Then, there's no need to ignore it)_.