### PR TITLE
Drop support for iOS 8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "Then",
   platforms: [
-    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
   ],
   products: [
     .library(name: "Then", targets: ["Then"]),

--- a/Then.podspec
+++ b/Then.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Then"
-  s.version          = "2.7.0"
+  s.version          = "3.0.0"
   s.summary          = "Super sweet syntactic sugar for Swift initializers."
   s.homepage         = "https://github.com/devxoul/Then"
   s.license          = { :type => "MIT", :file => "LICENSE" }
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc     = true
 
   s.swift_version = "5.0"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"


### PR DESCRIPTION
This alleviates warnings seen in iOS 14 targeted builds.