### PR TITLE
[Swift Package Manager] Remove Support for iOS 8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "Then",
   platforms: [
-    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
   ],
   products: [
     .library(name: "Then", targets: ["Then"]),


### PR DESCRIPTION
Xcode versions 12 and onward drop support for iOS 8. I'd like to request to update the minimum iphone os deployment target to iOS 9.