### PR TITLE
Add extension for JSONDecoder and JSONEncoder

### DIFF
--- a/Sources/Then/Then.swift
+++ b/Sources/Then/Then.swift
@@ -88,6 +88,8 @@ extension NSObject: Then {}
 extension Array: Then {}
 extension Dictionary: Then {}
 extension Set: Then {}
+extension JSONDecoder: Then {}
+extension JSONEncoder: Then {}
 
 #if os(iOS) || os(tvOS)
   extension UIEdgeInsets: Then {}


### PR DESCRIPTION
Add extension for JSONDecoder and JSONEncoder,

to use Then for JSONDecoder & JSONEncoder like below.
```
let decoder = JSONDecoder().then {
  $0.keyDecodingStrategy = .convertFromSnakeCase
}
```