### PR TITLE
Add async do(_:) for Swift Concurrency

### DIFF
--- a/Sources/Then/Then.swift
+++ b/Sources/Then/Then.swift
@@ -57,6 +57,15 @@ extension Then where Self: Any {
     try block(self)
   }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+  /// Async-friendly version of `.do` that accepts an async-throws closure.
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+  @inlinable
+  public func `do`(_ block: (Self) async throws -> Void) async rethrows {
+    try await block(self)
+  }
+#endif
+
 }
 
 extension Then where Self: AnyObject {

--- a/Tests/ThenTests/ThenTests.swift
+++ b/Tests/ThenTests/ThenTests.swift
@@ -15,6 +15,14 @@ struct User {
 }
 extension User: Then {}
 
+class Timer {
+  func run() async -> Bool {
+    try? await Task.sleep(nanoseconds: 1_000_000_000)
+    return true
+  }
+}
+extension Timer: Then {}
+
 class ThenTests: XCTestCase {
 
   func testThen_NSObject() {
@@ -63,6 +71,14 @@ class ThenTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: "username"), "devxoul")
   }
 
+  func testAsyncDo() async {
+    let t = Timer()
+    await t.do {
+      let obj = await $0.run()
+      XCTAssertTrue(obj)
+    }
+  }
+  
   func testRethrows() {
     XCTAssertThrowsError(
       try NSObject().do { _ in
@@ -70,5 +86,4 @@ class ThenTests: XCTestCase {
       }
     )
   }
-
 }


### PR DESCRIPTION
Adds an async version of `.do(_:)` so Then can handle asynchronous closures. It’s conditionally compiled and doesn’t break existing synchronous usage.

## Changes

- Introduces a new `do(_:)` with an async closure, gated by `#if swift(>=5.5) && canImport(_Concurrency)` and `@available(iOS 13, macOS 10.15, etc.)`.
- Leaves the original synchronous do(_:) untouched.

## Why

Avoids "cannot pass async closure to parameter expecting synchronous function type" errors.

Allows writing:
```swift
await object.do {  
  await someAsyncCall() 
}
```

## Compatibility

No breaking changes. Earlier Swift or platforms without concurrency continue using the sync `do(_:)`.
