### PR TITLE
Fix tvOS CI by installing simulator runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Install Tuist
         run: brew install tuist
 
+      - name: Install tvOS Simulator
+        if: matrix.platform == 'tvOS'
+        run: xcodebuild -downloadPlatform tvOS
+
       - name: Generate project
         run: tuist generate --no-open
 


### PR DESCRIPTION
## Summary
- The `macos-15` runner (Xcode 16.4) no longer ships with a pre-installed tvOS Simulator runtime, causing the tvOS CI job to fail with `Unable to find a device matching the provided destination specifier`.
- Add `xcodebuild -downloadPlatform tvOS` step that runs only for the tvOS matrix entry before build/test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tvOS CI by installing the tvOS Simulator runtime on macOS 15 (Xcode 16.4) runners. Adds a conditional step (xcodebuild -downloadPlatform tvOS) that runs only for the tvOS matrix to restore simulator devices and stop “Unable to find a device matching the provided destination specifier” failures.

<sup>Written for commit 4a0c8046bcd825fa409d0c9d30c2aeaa1a71ace2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

